### PR TITLE
[EHN, BUG] 유저 ResponseEntity적용, trasaction roll-back에러(해결)

### DIFF
--- a/src/main/java/com/sejong/eatnow/domain/user/User.java
+++ b/src/main/java/com/sejong/eatnow/domain/user/User.java
@@ -1,8 +1,10 @@
 package com.sejong.eatnow.domain.user;
 
+import com.sejong.eatnow.domain.chat.Chat;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Getter
 @ToString
@@ -13,23 +15,31 @@ import javax.persistence.*;
 public class User {
 
     @Id
+    @Column(name = "USER_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "EMAIL", nullable = false)
+    @Column(name = "EMAIL", unique = true, nullable = false)
     private String email;
 
     @Column(name = "NAME", length = 20)
     private String name;
 
-    @Builder
-    public User(String email, String name){
+    @ManyToMany
+    @JoinTable(name = "USER_CHAT",
+            joinColumns = @JoinColumn(name = "USER_ID"),
+            inverseJoinColumns = @JoinColumn(name = "CHAT_ID"))
+    private List<Chat> chats;
+
+    public void update(String email, String name) {
         this.email = email;
         this.name = name;
     }
 
-    public void update(String email, String name){
+    @Builder
+    public User(String email, String name) {
         this.email = email;
         this.name = name;
     }
+
 }

--- a/src/main/java/com/sejong/eatnow/domain/user/UserRepository.java
+++ b/src/main/java/com/sejong/eatnow/domain/user/UserRepository.java
@@ -4,10 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u ORDER BY u.id DESC")
     List<User> findAllDesc();
+
+    @Query("SELECT u FROM User u where u.email=?1")
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/sejong/eatnow/web/dto/UserRequestDto.java
+++ b/src/main/java/com/sejong/eatnow/web/dto/UserRequestDto.java
@@ -1,10 +1,12 @@
 package com.sejong.eatnow.web.dto;
 
 import com.sejong.eatnow.domain.user.User;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class UserRequestDto {
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1 +1,3 @@
 INSERT INTO user( email, name) VALUES ( "k@n","jung");
+INSERT INTO user( email, name) VALUES ( "jj@g","kim");
+INSERT INTO user( email, name) VALUES ( "ss4@d","lee");

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -13,6 +13,7 @@ Welcome, this is home
     name : <input type="text" name="name">
     <button type="button" id="submitBtn">제출</button>
 </form>
+
 </body>
 </html>
 <script type="text/javascript">
@@ -27,6 +28,28 @@ Welcome, this is home
 
         $.ajax({
             url: "/user/insert",
+            type: "POST",
+            data: JSON.stringify(data),
+            dataType: 'json',
+            contentType: 'application/json; charset=utf-8',
+
+            beforeSend: function(){
+                alert("submit_user()");
+            },
+            success: function(data){
+                alert(JSON.stringify(data)+'추가되었습니다.');
+            },
+            error: function(error){
+                alert("error: "+ JSON.stringify(error));
+            }
+
+        })
+
+
+        var user_id = 1;
+
+        $.ajax({
+            url: "/user/update/"+user_id,
             type: "POST",
             data: JSON.stringify(data),
             dataType: 'json',

--- a/src/test/java/com/sejong/eatnow/UserTest.java
+++ b/src/test/java/com/sejong/eatnow/UserTest.java
@@ -1,0 +1,99 @@
+package com.sejong.eatnow;
+
+import com.sejong.eatnow.domain.user.User;
+import com.sejong.eatnow.domain.user.UserRepository;
+import com.sejong.eatnow.web.dto.UserRequestDto;
+import lombok.extern.java.Log;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+@Log
+@Commit
+public class UserTest {
+    @Autowired
+    private UserRepository repo;
+
+    @Test
+    public void isQuery_findByEmail() {
+        UserRequestDto test = new UserRequestDto("k@n", null);
+
+
+            User target = repo.findByEmail(test.getEmail())
+                    .orElseThrow(()-> new NullPointerException("이메일로 찾을 수 없습니다."));
+            log.info("target:"+target.getEmail()+target.getName());
+    }
+
+    @Test
+    public void isQuery_findAllDesc() {
+        try {
+            List<User> target = repo.findAllDesc();
+            log.info("target"+target.toString());
+            for(User tmp :target){
+                log.info("target:"+ tmp.getId()+","+tmp.getName()+","+tmp.getEmail());
+            }
+        } catch (Exception e){      //-> data.sql에 user 아무것도 안 집어넣고 실행
+            log.info("exception: "+e.getMessage());
+        }
+    }
+
+    @Test
+    public void isError_insert(){
+        UserRequestDto dto = new UserRequestDto("ss4@d","lee");
+        try {
+            repo.saveAndFlush(dto.toEntity());
+        } catch (Exception e)  //email 값이 유일성을 가지므로 중복되면 예외처리.
+        {
+            log.warning("Exception:"+e.getMessage());
+        }
+    }
+    @Test
+    public void isError_saveUniqueEmails(){
+        User user = User.builder().email("k@n").build();
+
+        try{
+            repo.save(user);
+        }
+        catch (DataIntegrityViolationException e)
+        {
+            log.info("Exception : "+e.getMessage());
+        }
+    }
+
+    @Test
+    public void isError_update(){
+        Long id = Integer.toUnsignedLong(1);
+        UserRequestDto dto = new UserRequestDto("jj@g","ja");
+
+        User target = repo.findById(id).orElseThrow(
+                () -> new NullPointerException("찾는 유저가 없습니다."));
+        try {
+            target.update(dto.getEmail(), dto.getName());
+            repo.saveAndFlush(target);
+        } catch (DataIntegrityViolationException e)  //email 값이 유일성을 가지므로 중복되면 예외처리.
+        {
+            e.printStackTrace();
+        }
+
+    }
+    @Test
+    public void isError_deleteById(){
+        Long testId = Integer.toUnsignedLong(1000);
+
+        try{
+            repo.deleteById(testId);
+        }catch (EmptyResultDataAccessException e){
+            e.printStackTrace();
+        }
+    }
+}
+


### PR DESCRIPTION
** EHN:
- url 동일

** BUG-1(해결)
- 위치 : userService-> insert()
- 로그 : org.springframework.transaction.UnexpectedRollbackException: Transaction rolled back because it has been marked as rollback-only....
- 해결 : JpaReposity의 save는 자체적으로 tx를 가지고 있어 부모의 tx와 중복되면 tx 속성에 따라 전이를 일으켜야할 수 있다.... 인줄 알았으나 (대부분 이쪽으로 해결하는 것 같다)

        service에서 exception이 나온것을 aop에서 읽었지만,
        service에서 return될때 controller에서는 exception이 throw되지 않아, 어떠한 오류인지 확인이 불가하여 강제 roll back된 것!

- 요약: 예외던질 때 실수로 throw를 안썼더니 service에선 예외인지를 했지만 컨트롤러에서는 확인이 불가해서 생김.

** BUG-2 (미해결) sqlException 잡아낼 수 없음...
- 위치: userService -> update()
- 로그: o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
       o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry 'k@n' for key 'UK_ejfk3g58oxsgbb4ju3u4fhivk'
- 조사:
    -- 나처럼 sqlException은 sqlExceptionHelper에서 처리하여 ConstraintViolationException(유니크한 칼럼email과 중복되면 발생)을 잡아낼 수 없다는 개발자들 있었음
    -- 스프링의 JdbcTemplate은 모든 SQLException을 런타임 예외인 DataAccessException으로 포장해서 던져준다
- 요약: update메소드에서는 sqlExceptionHelper로 인한 예외처리 어려움. 일단 DataAccessException으로 예외처리, 추후 보수
Resolves #9 